### PR TITLE
Fix two index out of bounds exceptions.

### DIFF
--- a/HON Mod Manager/MainForm.cs
+++ b/HON Mod Manager/MainForm.cs
@@ -94,7 +94,7 @@ namespace CS_ModMan
             if (m_modUpdaters.Count > 0)
             {
                 ModUpdater[] myList = m_modUpdaters.ToArray();
-                string[] SortKeys = new string[m_modUpdaters.Count - 1];
+                string[] SortKeys = new string[m_modUpdaters.Count];
                 int i = 0;
                 foreach (ModUpdater tModUpdater in m_modUpdaters)
                 {

--- a/HON Mod Manager/ModUpdater.cs
+++ b/HON Mod Manager/ModUpdater.cs
@@ -154,8 +154,8 @@ namespace CS_ModMan
                 HttpWebResponse myHttpWebResponse = (HttpWebResponse) myWebRequest.GetResponse();
                 StreamReader myStreamReader = new StreamReader(myHttpWebResponse.GetResponseStream());
                 //only read up to 20 characters
-                char[] tCharBuffer = new char[19];
-                Array.Resize(ref tCharBuffer, myStreamReader.ReadBlock(tCharBuffer, 0, 20));
+                char[] tCharBuffer = new char[20];
+                Array.Resize(ref tCharBuffer, myStreamReader.ReadBlock(tCharBuffer, 0, tCharBuffer.Length));
                 m_newestVersion = new string(tCharBuffer);
                 myStreamReader.Close();
                 myHttpWebResponse.Close();


### PR DESCRIPTION
These trigger whenever trying to update a honmod.

In `MainForm.cs`:

```
The thread 0x21cc has exited with code 0 (0x0).
Exception thrown: 'System.IndexOutOfRangeException' in HoN_ModMan.exe
An unhandled exception of type 'System.IndexOutOfRangeException' occurred in HoN_ModMan.exe
Index was outside the bounds of the array.
```

In `ModUpdater.cs`:
```
Exception thrown: 'System.ArgumentException' in mscorlib.dll
System.ArgumentException: Offset and length were out of bounds for the array or count is greater than the number of elements from index to the end of the source collection.
   at System.IO.StreamReader.ReadBlock(Char[] buffer, Int32 index, Int32 count)
   at CS_ModMan.ModUpdater.UpdateThread() in D:\GitHub\Heroes-Of-Newerth-Mod-Manager\HON Mod Manager\ModUpdater.cs:line 158
The thread 0x4480 has exited with code 0 (0x0).
```