### PR TITLE
Fix an issue with `m_bytes` never being initialized.

### DIFF
--- a/HON Mod Manager/ModUpdater.cs
+++ b/HON Mod Manager/ModUpdater.cs
@@ -181,6 +181,7 @@ namespace CS_ModMan
 
                 int ReadAmount;
                 Stream myResponseStream = myHttpWebResponse.GetResponseStream();
+                m_bytes = new byte[m_size];
                 do
                 {
                     if (m_abortRequested)


### PR DESCRIPTION
Passing in `null` to the `Read()` method was causing exceptions to be thrown, which was caught and treated as a "failure".

Exception:
```
Exception thrown: 'System.ArgumentNullException' in System.dll
System.ArgumentNullException: Value cannot be null.
Parameter name: buffer
   at System.Net.ConnectStream.Read(Byte[] buffer, Int32 offset, Int32 size)
   at CS_ModMan.ModUpdater.UpdateThread() in D:\GitHub\Heroes-Of-Newerth-Mod-Manager\HON Mod Manager\ModUpdater.cs:line 194
The thread 0x408c has exited with code 0 (0x0).
```