### PR TITLE
Add a failure check for invalid version files.

### DIFF
--- a/HON Mod Manager/ModUpdater.cs
+++ b/HON Mod Manager/ModUpdater.cs
@@ -160,6 +160,13 @@ namespace CS_ModMan
                 myStreamReader.Close();
                 myHttpWebResponse.Close();
 
+                float f;
+                if (!float.TryParse(m_newestVersion, out f))
+                {
+                   m_status = ModUpdaterStatus.Failed;
+                   return;
+                }
+
                 if (Tools.IsNewerVersion(m_newestVersion, m_mod.Version))
                 {
                     m_status = ModUpdaterStatus.NoUpdatePresent;


### PR DESCRIPTION
If the file is not a text file with the version number as the only string, then this should be treated as a failure.

As-is, it was reporting this incorrectly as "Up to date" in most cases.