### PR TITLE
Remove UTF-8 BOM file preamble to fix Lua mods.

### DIFF
--- a/HON Mod Manager/MainForm.cs
+++ b/HON Mod Manager/MainForm.cs
@@ -3160,6 +3160,12 @@ namespace CS_ModMan
             StreamReader myTextReader = new StreamReader(Data);
             string myOutput = myTextReader.ReadToEnd();
             Encoding = myTextReader.CurrentEncoding;
+            // Remove the UTF-8 BOM marker by creating a custom encoding. This is necessary
+            // to support writing Lua files that HoN can parse.
+            if (Encoding.GetType() == typeof(System.Text.UTF8Encoding))
+            {
+                Encoding = new UTF8Encoding(false);
+            }
             return myOutput.Replace(Convert.ToChar(13), ' ');
         }
 


### PR DESCRIPTION
This change creates a new UTF-8 encoding whenever one is parsed from
a `Decode()` operation. This is done to opt out of the optional BOM
marker.

This marker was causing HoN's game engine to fail to parse Lua files
that contained this preamble.

Fixes https://github.com/Xen0byte/Heroes-Of-Newerth-Mod-Manager/issues/9

"""
The UTF-8 representation of the BOM is the (hexadecimal) byte sequence
0xEF,0xBB,0xBF.

The Unicode Standard permits the BOM in UTF-8,[3] but does not require
or recommend its use.[4] Byte order has no meaning in UTF-8,[5] so its
only use in UTF-8 is to signal at the start that the text stream is
encoded in UTF-8, or that it was converted to UTF-8 from a stream that
contained an optional BOM.
"""
https://en.wikipedia.org/wiki/Byte_order_mark#UTF-8
